### PR TITLE
fix: use items() for py2.7 + py3 compatibility

### DIFF
--- a/geomeppy/idf.py
+++ b/geomeppy/idf.py
@@ -269,7 +269,7 @@ class IDF(PatchedIDF):
             try:
                 for name, coords in core_perim_zone_coordinates(
                     block.coordinates, block.perim_depth
-                )[0].iteritems():
+                )[0].items():
                     block = Block(
                         name=name,
                         coordinates=coords,


### PR DESCRIPTION
I am running into the python3  'core/perim' issue that #88 fixes, among other things.  #88 has several conflicts and a big diff that I don't fully understand so I am submitting this fix as separate PR.