### PR TITLE
Update recipes.py

### DIFF
--- a/geomeppy/recipes.py
+++ b/geomeppy/recipes.py
@@ -215,11 +215,12 @@ def window_vertices_given_wall(wall, wwr):
     average_y = sum([y for _x, y, _z in vertices]) / len(vertices)
     average_z = sum([z for _x, _y, z in vertices]) / len(vertices)
     # move windows in 0.5% from the edges so they can be drawn in SketchUp
+    wwr_factor = np.sqrt(wwr) 
     window_points = [
         [
-            ((x - average_x) * 0.999) + average_x,
-            ((y - average_y) * 0.999) + average_y,
-            ((z - average_z) * wwr) + average_z,
+            x*wwr_factor*0.999 + average_x*(1-wwr_factor),
+            y*wwr_factor*0.999 + average_y*(1-wwr_factor),
+            z*wwr_factor*0.999 + average_z*(1-wwr_factor),
         ]
         for x, y, z in vertices
     ]


### PR DESCRIPTION
### PURPOSE
The calculation of the window coordinates has been modified using the weighted vectors of the X Y Z coordinates so that triangular windows don't extend of the surface anymore. Rectangular windows geometry also looks a bit more realistic. 

### TEST with updated recipes.py

**With the following Geomeppy WWR configuration:**
idf.set_wwr(wwr_map={90: 0.1 ,180: 0.4,270: 0.7,0: 1.0})    

**The corresponding E+ HTML TAB is:**
![HTMLresultsWWR](https://user-images.githubusercontent.com/65318981/89441848-14867b00-d74e-11ea-8aac-9012d7f96b13.PNG)

There is a slight discrepancy due to the 0.999 factor but the WWR in the table are equal to the input values.


