### PR TITLE
Fixes an issue where not all wwr_map orientations are processed

### DIFF
--- a/geomeppy/recipes.py
+++ b/geomeppy/recipes.py
@@ -163,9 +163,9 @@ def set_wwr(
         # remove all subsurfaces
         for ss in wall_subsurfaces:
             idf.removeidfobject(ss)
-        wwr = (wwr_map or {}).get(wall.azimuth) or base_wwr
+        wwr = (wwr_map or {}).get(wall.azimuth, base_wwr)
         if not wwr:
-            return
+            continue
         coords = window_vertices_given_wall(wall, wwr)
         window = idf.newidfobject(
             "FENESTRATIONSURFACE:DETAILED",


### PR DESCRIPTION
Because of the `return` satement at line 168, if one of the `wwr` is zero, the conditonal statment on the previous line will be True and the method will exit, ignoring the next walls in the loop. Changing to `continue`, allows the loop to finish.

Also, the `or base` on line 166 conflicts with the truth value of `0`, eg: 
```python
>>> 0 or 10
10  # but we want 0; Could have a north facade with 0% wwr.
```
what is needed is something like:

```python
>>> wwr = (wwr_map or {}).get(wall.azimuth, base_wwr)
```
where `base_wwr` becomes the fallback value of the `dict.get()` method (which would fail if `{}` wins over `wwr_map`.