### PR TITLE
Improve orientation check (buggy for angles > 315 degrees so far)

### DIFF
--- a/geomeppy/recipes.py
+++ b/geomeppy/recipes.py
@@ -183,7 +183,7 @@ def _has_correct_orientation(wall, orientation_degrees):
     """
     if orientation_degrees is None:
         return True
-    if abs((wall.azimuth - orientation_degrees + 180 + 360) % 360 - 180) < 45:
+    if abs((wall.azimuth - orientation_degrees + 180) % 360 - 180) < 45:
         return True
     return False
 

--- a/geomeppy/recipes.py
+++ b/geomeppy/recipes.py
@@ -183,7 +183,7 @@ def _has_correct_orientation(wall, orientation_degrees):
     """
     if orientation_degrees is None:
         return True
-    if abs(wall.azimuth - orientation_degrees) < 45:
+    if abs((wall.azimuth - orientation_degrees + 180 + 360) % 360 - 180) < 45:
         return True
     return False
 


### PR DESCRIPTION
When wall.azimuth > 315º and orientation_degrees = 0º (north) the calculation doesn't work anymore

ex: wall.azimuth = 350º
abs(350 - 0) < 45 returns False

New formula aims to solve this problem 