### PR TITLE
issue #264: fixed MutableSequence import from collections (it now is collections.abc)

### DIFF
--- a/geomeppy/geom/polygons.py
+++ b/geomeppy/geom/polygons.py
@@ -1,5 +1,5 @@
 """Heavy lifting geometry for IDF surfaces."""
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from itertools import product
 from math import atan2, pi
 from typing import Any, List, Optional, Tuple, Union  # noqa


### PR DESCRIPTION
I was having the error which is mentioned in issue #264 : 
`ImportError: cannot import name 'MutableSequence' from 'collections'`

According to [this StackOverflow answer](https://stackoverflow.com/a/70870087/18211609):

> You need to import collections.abc

> Here the [link to doc](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping)

> Deprecated since version 3.3, will be removed in version 3.10: Moved [Collections Abstract Base Classes](https://docs.python.org/3.9/library/collections.abc.html#collections-abstract-base-classes) to the [collections.abc](https://docs.python.org/3.9/library/collections.abc.html#module-collections.abc) module. For backwards compatibility, they continue to be visible in this module through Python 3.9.

> Ref. [https://docs.python.org/3.9/library/](https://docs.python.org/3.9/library/collections.html)

This PR fixes this particular error. I've tested it locally and it seems to work on my machine, however this is my first contribution to a public repo so I'm not 100 % shure that it's replicable everywhere (it should, because it is the "collections" package that has changed its internal structure).

I've tried running the tests, and some of them fail (one esoreader import, some related with the EnergyPlus version that is hardcoded, etc.). However, when I try to run the tests from the `master` branch, they fail too at the "collections" import. In order to keep thinks compartimentalized, I'll try to document the issues with the tests as separate issues, and perhaps I'll try fixing them. 

I realize that the repo is not being "actively" worked on--so to speak--but so far it has been invaluable for my work so this is my humble attempt to contributing to this great project!