### PR TITLE
Fix tutorial and issue #209

### DIFF
--- a/docs/source/Start here.rst
+++ b/docs/source/Start here.rst
@@ -102,7 +102,7 @@ Now we need to tell `geomeppy` to match up our surfaces with the correct outside
 
 Last step, let's add some nice big windows. We'll set window to wall ratio (WWR) of 0.6 for all external walls.
 
-    >>> idf.set_wwr(0.6)
+    >>> idf.set_wwr(0.6, construction="Project External Window")
 
 So what have we built? We can export the IDF geometry as an OBJ file, a format that can be imported into a 3D geometry viewer.
 

--- a/geomeppy/geom/polygons.py
+++ b/geomeppy/geom/polygons.py
@@ -1,5 +1,5 @@
 """Heavy lifting geometry for IDF surfaces."""
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from itertools import product
 from math import atan2, pi
 from typing import Any, List, Optional, Tuple, Union  # noqa


### PR DESCRIPTION
This PR fixes the documentation on the error reported in issue #209 

A year ago [I posted a fix for the error](https://github.com/jamiebull1/geomeppy/issues/209#issuecomment-1103686087), but didn't submit any PRs (my bad).

> I had the same issue that you had when trying to replicate the tutorial.
Apparently the function set_wwr needs a construction parameter in the function, which by default is None.
I replaced idf.set_wwr(0.6) with idf.set_wwr(0.6,construction="Project External Window"), which I believe is the default for windows defined in idf.set_default_constructions(), and now seems to be working correctly.

The branch from which I am submitting this PR (`fix-tutorial`) stems from the one called `fix-collections`, of which [I submitted a PR some minutes ago](https://github.com/jamiebull1/geomeppy/pull/268#issue-1996783951), because without the fix to "collections" it is impossible for me to use the repo.